### PR TITLE
解決 postcss-values-parser 出現 Syntax Error 的問題

### DIFF
--- a/scripts/creatRollupConfig.js
+++ b/scripts/creatRollupConfig.js
@@ -47,7 +47,12 @@ module.exports = function creatRollupConfig(projectPath) {
                 plugins: [
                     autoprefixer(),
                     cssnano({
-                        preset: 'default',
+                        preset: [
+                            'default',
+                            {
+                                calc: false
+                            }
+                        ],
                     }),
                 ],
                 sourceMap: isProd ? false : true,


### PR DESCRIPTION
ArtPlayer 的 **dist/artplayer.css** 在某些環境下的 PostCSS 會出現 Syntax Error。

## 原因

Rollup 會將 balloon.css 中的 `calc(var(--balloon-move) * -1))` minify 成 `calc(var(--balloon-move)*-1))`，前後的空格被移除。

這在一些使用 [postcss-values-parser](https://github.com/shellscape/postcss-values-parser) 的環境底下會出現 Syntax Error（例如 Ruby on Rails 的 webpacker）：

<img width="1440" alt="Screen Shot 2019-08-21 at 10 24 21 AM" src="https://user-images.githubusercontent.com/559351/63397655-e05f6080-c3fd-11e9-84c5-a60ad419b296.png">

原本 `calc(200*-1))` 這種情況是不會出現錯誤的，但是 postcss-values-parser 沒考慮到 `calc(var())` 的情況。

附上相關 issue 討論 https://github.com/postcss/postcss-custom-properties/issues/161#issuecomment-479025016

## 解決方式

取消 cssnano 對 `calc` 的 minify，確保還在使用 postcss-values-parser 的人不會碰到相同問題。