### PR TITLE
使用 DOMParser 解析弹幕 XML 文件

### DIFF
--- a/packages/artplayer-plugin-danmuku/src/bilibili.js
+++ b/packages/artplayer-plugin-danmuku/src/bilibili.js
@@ -14,26 +14,26 @@ export function getMode(key) {
 
 export function bilibiliDanmuParseFromXml(xmlString) {
     if (typeof xmlString !== 'string') return [];
-    const srtList = xmlString.match(/<d([\S ]*?>[\S ]*?)<\/d>/gi);
-    return srtList && srtList.length
-        ? srtList.map((item) => {
-              const [, attrStr, text] = item.match(/<d p="(.+)">(.+)<\/d>/);
-              const attr = attrStr.split(',');
-              return attr.length === 8 && text.trim()
-                  ? {
-                        text,
-                        time: Number(attr[0]),
-                        mode: getMode(Number(attr[1])),
-                        fontSize: Number(attr[2]),
-                        color: `#${Number(attr[3]).toString(16)}`,
-                        timestamp: Number(attr[4]),
-                        pool: Number(attr[5]),
-                        userID: attr[6],
-                        rowID: Number(attr[7]),
-                    }
-                  : null;
-          })
-        : [];
+    try {
+        let parsedXml = (new DOMParser()).parseFromString(xmlString, 'text/xml');
+        return Array.from(parsedXml.querySelectorAll('d')).map((d) => {
+            let attr = d.attributes.p.value.split(',');
+            return {
+                text: d.textContent,
+                time: Number(attr[0]),
+                mode: getMode(Number(attr[1])),
+                fontSize: Number(attr[2]),
+                color: `#${Number(attr[3]).toString(16)}`,
+                timestamp: Number(attr[4]),
+                pool: Number(attr[5]),
+                userID: attr[6],
+                rowID: Number(attr[7])
+            }
+        }
+        )
+    } catch (error) {
+        return [];
+    }
 }
 
 export function bilibiliDanmuParseFromUrl(url) {


### PR DESCRIPTION
这样的实现更标准，主要有两个优点：
1. 能正确处理转义过的字符，如 `<d p="2,1,25,16777215,0,0,0,0">&lt;&lt;&lt;&lt;</d>`
2. 能支持其他“兼容”B站弹幕XML格式的弹幕文件

这个 PR 是在 GitHub 网页上编辑的，有可能有疏漏，麻烦检查一下。

可能需要确认一下性能方面没有大的影响，我还没有测试。