### PR TITLE
修改匹配 XML 弹幕的正则表达式

### DIFF
--- a/packages/artplayer-plugin-danmuku/src/bilibili.js
+++ b/packages/artplayer-plugin-danmuku/src/bilibili.js
@@ -14,26 +14,31 @@ export function getMode(key) {
 
 export function bilibiliDanmuParseFromXml(xmlString) {
     if (typeof xmlString !== 'string') return [];
-    const srtList = xmlString.match(/<d([\S ]*?>[\S ]*?)<\/d>/gi);
-    return srtList && srtList.length
-        ? srtList.map((item) => {
-              const [, attrStr, text] = item.match(/<d p="(.+)">(.+)<\/d>/);
-              const attr = attrStr.split(',');
-              return attr.length === 8 && text.trim()
-                  ? {
-                        text,
-                        time: Number(attr[0]),
-                        mode: getMode(Number(attr[1])),
-                        fontSize: Number(attr[2]),
-                        color: `#${Number(attr[3]).toString(16)}`,
-                        timestamp: Number(attr[4]),
-                        pool: Number(attr[5]),
-                        userID: attr[6],
-                        rowID: Number(attr[7]),
-                    }
-                  : null;
-          })
-        : [];
+    const matches = xmlString.matchAll(/<d (?:.*? )??p="(?<p>.+?)"(?: .*?)?>(?<text>.+?)<\/d>/gs);
+    return Array.from(matches).map(match => {
+        const attr = match.groups.p.split(',');
+        if (attr.length === 8) {
+            const text = match.groups.text.trim()
+                .replaceAll('&quot;', '\"')
+                .replaceAll('&apos;', '\'')
+                .replaceAll('&lt;', '<')
+                .replaceAll('&gt;', '>')
+                .replaceAll('&amp;', '&');
+            return {
+                text,
+                time: Number(attr[0]),
+                mode: getMode(Number(attr[1])),
+                fontSize: Number(attr[2]),
+                color: `#${Number(attr[3]).toString(16)}`,
+                timestamp: Number(attr[4]),
+                pool: Number(attr[5]),
+                userID: attr[6],
+                rowID: Number(attr[7]),
+            }
+        } else {
+            return null;
+        }
+    }).filter(d => d);
 }
 
 export function bilibiliDanmuParseFromUrl(url) {


### PR DESCRIPTION
测试例：

```xml
<i>
  <chatserver>chat.bilibili.com</chatserver>
  <chatid>0</chatid>
  <mission>0</mission>
  <maxlimit>1000</maxlimit>
  <state>0</state>
  <real_name>0</real_name>
  <source>0</source>
  <d p="0.465,5,25,26214,1480410348,11,e6d2b8ad,2704552969">泷：三叶，请记住我的名字“I LOVE YOU”</d><d beforea="value" beforeb="value" p="0.302,1,25,16777215,0,0,1,0" aftera="value" afterb="&quot;">正文内容</d><d p="2,1,25,16777215,0,0,0,0">&lt;&gt;&quot;&apos;&amp;</d>
<d p="3,1,25,16777215,0,0,0,0">
   XML可以换行缩进
</d><d beforea="value" 
beforeb="value"   p="0.302,1,25,16777215,0,0,1,0" 
 aftera="value" afterb="&quot;">attribute 换行</d>
<d     p="3,1,25,16777215,0,0,0,0"    >p=&quot;前面有多个空格</d>
</i>
```