### PR TITLE
add support for real mobile progressbar dragging

### DIFF
--- a/packages/artplayer/src/events/gestureInit.js
+++ b/packages/artplayer/src/events/gestureInit.js
@@ -44,7 +44,7 @@ export default function gestureInit(art, events) {
                 isDroging = false;
             }
         };
-
+        /*
         events.proxy($bottom, 'touchstart', (event) => {
             if (!includeFromEvent(event, $controls)) {
                 onTouchStart(event);
@@ -52,6 +52,7 @@ export default function gestureInit(art, events) {
         });
 
         events.proxy($bottom, 'touchmove', onTouchMove);
+        */
         events.proxy($video, 'touchstart', onTouchStart);
         events.proxy($video, 'touchmove', onTouchMove);
         events.proxy(document, 'touchend', onTouchEnd);


### PR DESCRIPTION
支持移动端的进度条的真正拖拽，现有的移动端时间跳转是在$player上监听滑动手势来跳转时间，这样的话即使去滑动进度条，时间的跳转依旧是按照手指在屏幕上滑动的长度和设定的倍率的乘积来前进/后退相应的秒数，与进度条是没有关系的，进度条指示器是不跟手的，没有实现单独对进度条滑动的监听，用户去滑动进度条会发现根本无法去控制它。改进之后的进度条增加了滑动监听，当在移动端去滑动进度条的时候，手指滑到哪，指示器就跟到哪，时间的跳转就是按照进度条指示器的位置进行跳转；当滑动除了进度条以外的区域时，还是按照原来的逻辑处理，这样也符合正常的操作逻辑。