### PR TITLE
修复firefox字幕不显示的问题

### DIFF
--- a/packages/artplayer/src/subtitle.js
+++ b/packages/artplayer/src/subtitle.js
@@ -87,6 +87,7 @@ export default class Subtitle extends Component {
         $newTrack.default = true;
         $newTrack.kind = kind;
         $newTrack.src = url;
+        $newTrack.track.mode = 'hidden';
 
         this.eventDestroy();
         remove($track);


### PR DESCRIPTION
ArtPlayer在firefox下新插入的`<track>`的mode默认是**disabled**（原因未知，我本地也没能用其他demo重现），导致**cuechange**事件不触发，字幕不显示。
加了一行代码，强制设置mode为**hidden**。