### PR TITLE
not trigger shortcuts when ctrl or command key is pressed

### DIFF
--- a/packages/artplayer/src/hotkey.js
+++ b/packages/artplayer/src/hotkey.js
@@ -43,7 +43,7 @@ export default class Hotkey {
             if (this.art.isFocus) {
                 const tag = document.activeElement.tagName.toUpperCase();
                 const editable = document.activeElement.getAttribute('contenteditable');
-                if (tag !== 'INPUT' && tag !== 'TEXTAREA' && editable !== '' && editable !== 'true' && !event.ctrlKey && !event.metaKey) {
+                if (tag !== 'INPUT' && tag !== 'TEXTAREA' && editable !== '' && editable !== 'true' && !event.altKey && !event.ctrlKey && !event.metaKey && !event.shiftKey) {
                     const events = this.keys[event.keyCode];
                     if (events) {
                         event.preventDefault();

--- a/packages/artplayer/src/hotkey.js
+++ b/packages/artplayer/src/hotkey.js
@@ -43,7 +43,7 @@ export default class Hotkey {
             if (this.art.isFocus) {
                 const tag = document.activeElement.tagName.toUpperCase();
                 const editable = document.activeElement.getAttribute('contenteditable');
-                if (tag !== 'INPUT' && tag !== 'TEXTAREA' && editable !== '' && editable !== 'true') {
+                if (tag !== 'INPUT' && tag !== 'TEXTAREA' && editable !== '' && editable !== 'true' && !event.ctrlKey && !event.metaKey) {
                     const events = this.keys[event.keyCode];
                     if (events) {
                         event.preventDefault();


### PR DESCRIPTION
It will conflict with some of the browser shortcuts when the video element is in focus.