### PR TITLE
remove updateStyle

### DIFF
--- a/packages/artplayer/src/control/setting.js
+++ b/packages/artplayer/src/control/setting.js
@@ -11,7 +11,6 @@ export default function setting(option) {
 
             proxy($control, 'click', () => {
                 art.setting.toggle();
-                art.setting.updateStyle();
             });
 
             art.on('setting', (value) => {

--- a/packages/artplayer/src/setting/index.js
+++ b/packages/artplayer/src/setting/index.js
@@ -390,28 +390,6 @@ export default class Setting extends Component {
         return $item;
     }
 
-    updateStyle(width) {
-        const {
-            controls,
-            constructor,
-            template: { $player, $setting },
-        } = this.art;
-
-        if (controls.setting && !isMobile) {
-            const settingWidth = width || constructor.SETTING_WIDTH;
-            const { left: controlLeft, width: controlWidth } = controls.setting.getBoundingClientRect();
-            const { left: playerLeft, width: playerWidth } = $player.getBoundingClientRect();
-            const settingLeft = controlLeft - playerLeft + controlWidth / 2 - settingWidth / 2;
-            if (settingLeft + settingWidth > playerWidth) {
-                setStyle($setting, 'left', null);
-                setStyle($setting, 'right', null);
-            } else {
-                setStyle($setting, 'left', `${settingLeft}px`);
-                setStyle($setting, 'right', 'auto');
-            }
-        }
-    }
-
     render(option, width) {
         const { constructor } = this.art;
 
@@ -420,7 +398,6 @@ export default class Setting extends Component {
             inverseClass($panel, 'art-current');
             setStyle(this.$parent, 'width', `${$panel.dataset.width}px`);
             setStyle(this.$parent, 'height', `${$panel.dataset.height}px`);
-            this.updateStyle(Number($panel.dataset.width));
         } else {
             const $panel = createElement('div');
             addClass($panel, 'art-setting-panel');
@@ -448,7 +425,6 @@ export default class Setting extends Component {
             inverseClass($panel, 'art-current');
             setStyle(this.$parent, 'width', `${$panel.dataset.width}px`);
             setStyle(this.$parent, 'height', `${$panel.dataset.height}px`);
-            this.updateStyle(Number($panel.dataset.width));
 
             if (option[0] && option[0].$parentItem && option[0].$parentItem.mounted) {
                 option[0].$parentItem.mounted.call(this.art, $panel, option[0].$parentItem);

--- a/packages/artplayer/types/artplayer.d.ts
+++ b/packages/artplayer/types/artplayer.d.ts
@@ -157,7 +157,6 @@ declare class Artplayer extends Player {
 
     readonly setting: {
         option: SettingOption[];
-        updateStyle(width?: number): void;
         find(name: string): SettingOption;
         add(setting: Setting): SettingOption[];
         update(settings: Setting): SettingOption[];


### PR DESCRIPTION
Fix [737](https://github.com/zhw2590582/ArtPlayer/issues/737).

It appears when rendering a new setting, it's already correctly displayed. The setting will stick to the right of the player by default. The offset will cause the setting to go out of sync if the player size is changed.