### PR TITLE
seek when video metadata is ready in switch url

### DIFF
--- a/packages/artplayer/src/player/switchMix.js
+++ b/packages/artplayer/src/player/switchMix.js
@@ -11,10 +11,12 @@ export default function switchMix(art) {
             art.notice.show = '';
 
             art.once('video:error', reject);
+            art.once('video:loadedmetadata', () => {
+                art.currentTime = currentTime;
+            });
             art.once('video:canplay', async () => {
                 art.playbackRate = playbackRate;
                 art.aspectRatio = aspectRatio;
-                art.currentTime = currentTime;
 
                 if (playing) {
                     await art.play();


### PR DESCRIPTION
When switching url, there is a brief second when the first frame of the new video is shown. Seek when metadata is ready to avoid this.