### PR TITLE
倍速快进优化 & 全屏时上下滑动调节音量

### DIFF
--- a/docs/uncompiled/artplayer/index.js
+++ b/docs/uncompiled/artplayer/index.js
@@ -380,6 +380,7 @@ Artplayer.INFO_LOOP_TIME = 1000;
 Artplayer.FAST_FORWARD_VALUE = 3;
 Artplayer.FAST_FORWARD_TIME = 1000;
 Artplayer.TOUCH_MOVE_RATIO = 0.5;
+Artplayer.TOUCH_MOVE_VOLUME_RATIO = 1.2;
 Artplayer.VOLUME_STEP = 0.1;
 Artplayer.SEEK_STEP = 5;
 Artplayer.PLAYBACK_RATE = [
@@ -4113,6 +4114,7 @@ function gestureInit(art, events) {
         let startX = 0;
         let startY = 0;
         let startTime = 0;
+        let startVolume = 0;
         const onTouchStart = (event)=>{
             if (event.touches.length === 1 && !art.isLock && !art.isFastForwarding) {
                 if (touchTarget === $progress) (0, _progress.setCurrentTime)(art, event);
@@ -4121,6 +4123,7 @@ function gestureInit(art, events) {
                 startX = pageX;
                 startY = pageY;
                 startTime = art.currentTime;
+                startVolume = art.volume;
             }
         };
         const onTouchMove = (event)=>{
@@ -4136,15 +4139,27 @@ function gestureInit(art, events) {
                     2
                 ].includes(direction);
                 const isLegal = isHorizontal && !art.isRotate || isVertical && art.isRotate;
-                if (isLegal) {
+                // 禁用未旋转时的触摸音量调节, 以防止误触
+                const isLegalVolumeAction = /*isHorizontal && art.isRotate ||*/ isVertical && !art.isRotate;
+                if (isLegal || isLegalVolumeAction) {
                     const ratioX = (0, _utils.clamp)((pageX - startX) / art.width, -1, 1);
                     const ratioY = (0, _utils.clamp)((pageY - startY) / art.height, -1, 1);
-                    const ratio = art.isRotate ? ratioY : ratioX;
-                    const TOUCH_MOVE_RATIO = touchTarget === $video ? art.constructor.TOUCH_MOVE_RATIO : 1;
-                    const currentTime = (0, _utils.clamp)(startTime + art.duration * ratio * TOUCH_MOVE_RATIO, 0, art.duration);
-                    art.seek = currentTime;
-                    art.emit("setBar", "played", (0, _utils.clamp)(currentTime / art.duration, 0, 1), event);
-                    art.notice.show = `${(0, _utils.secondToTime)(currentTime)} / ${(0, _utils.secondToTime)(art.duration)}`;
+
+                    if (isLegal) {
+                        const ratio = art.isRotate ? ratioY : ratioX;
+                        const TOUCH_MOVE_RATIO = touchTarget === $video ? art.constructor.TOUCH_MOVE_RATIO : 1;
+                        const currentTime = (0, _utils.clamp)(startTime + art.duration * ratio * TOUCH_MOVE_RATIO, 0, art.duration);
+                        art.seek = currentTime;
+                        art.emit("setBar", "played", (0, _utils.clamp)(currentTime / art.duration, 0, 1), event);
+                        art.notice.show = `${(0, _utils.secondToTime)(currentTime)} / ${(0, _utils.secondToTime)(art.duration)}`;
+                    } else {    // 音量
+                        const ratio = art.isRotate ? ratioX : ratioY;
+                        // 直接使用ratio会导致音量调节过慢
+                        const currentVolume = (0, _utils.clamp)(startVolume - 1 * ratio * TOUCH_MOVE_VOLUME_RATIO, 0, 1);
+                        art.volume = currentVolume;
+                        // 位运算以取整
+                        art.notice.show = `音量: ${(currentVolume * 100) >> 0}%`;
+                    }
                 }
             }
         };

--- a/docs/uncompiled/artplayer/index.js
+++ b/docs/uncompiled/artplayer/index.js
@@ -206,7 +206,6 @@ class Artplayer extends (0, _emitterDefault.default) {
         this.isRotate = false;
         this.isDestroy = false;
         this.isFastForwarding = false;
-        this.localDate = new Date;
         // 上次滑动的时间(音量/进度)
         this.lastSwipeTime = 0;
         this.template = new (0, _templateDefault.default)(this);
@@ -4167,7 +4166,7 @@ function gestureInit(art, events) {
 
                 // 更新滑动时间
                 // 以便于长按倍速功能的激活判定
-                art.lastSwipeTime = art.localDate.getTime();
+                art.lastSwipeTime = Date.now();
             }
         };
         const onTouchEnd = ()=>{
@@ -5307,7 +5306,7 @@ function fastForward(art) {
     const onStart = (event)=>{
         if (event.touches.length === 1 && art.playing && !art.isLock) timer = setTimeout(()=>{
             // 上次滑动时间
-            let curTime = art.localDate.getTime();
+            let curTime = Date.now();
             let timeDiff = curTime - art.lastSwipeTime;
             if (timeDiff < constructor.FAST_FORWARD_TIME) {
                 return

--- a/docs/uncompiled/artplayer/index.js
+++ b/docs/uncompiled/artplayer/index.js
@@ -206,6 +206,9 @@ class Artplayer extends (0, _emitterDefault.default) {
         this.isRotate = false;
         this.isDestroy = false;
         this.isFastForwarding = false;
+        this.localDate = new Date;
+        // 上次滑动的时间(音量/进度)
+        this.lastSwipeTime = 0;
         this.template = new (0, _templateDefault.default)(this);
         this.events = new (0, _eventsDefault.default)(this);
         this.storage = new (0, _storageDefault.default)(this);
@@ -4161,6 +4164,10 @@ function gestureInit(art, events) {
                         art.notice.show = `音量: ${(currentVolume * 100) >> 0}%`;
                     }
                 }
+
+                // 更新滑动时间
+                // 以便于长按倍速功能的激活判定
+                art.lastSwipeTime = art.localDate.getTime();
             }
         };
         const onTouchEnd = ()=>{
@@ -5299,6 +5306,13 @@ function fastForward(art) {
     let lastPlaybackRate = 1;
     const onStart = (event)=>{
         if (event.touches.length === 1 && art.playing && !art.isLock) timer = setTimeout(()=>{
+            // 上次滑动时间
+            let curTime = art.localDate.getTime();
+            let timeDiff = curTime - art.lastSwipeTime;
+            if (timeDiff < constructor.FAST_FORWARD_TIME) {
+                return
+            }
+            
             isPress = true;
             lastPlaybackRate = art.playbackRate;
             art.playbackRate = constructor.FAST_FORWARD_VALUE;

--- a/docs/uncompiled/artplayer/index.js
+++ b/docs/uncompiled/artplayer/index.js
@@ -205,6 +205,7 @@ class Artplayer extends (0, _emitterDefault.default) {
         this.isInput = false;
         this.isRotate = false;
         this.isDestroy = false;
+        this.isFastForwarding = false;
         this.template = new (0, _templateDefault.default)(this);
         this.events = new (0, _eventsDefault.default)(this);
         this.storage = new (0, _storageDefault.default)(this);
@@ -4113,7 +4114,7 @@ function gestureInit(art, events) {
         let startY = 0;
         let startTime = 0;
         const onTouchStart = (event)=>{
-            if (event.touches.length === 1 && !art.isLock) {
+            if (event.touches.length === 1 && !art.isLock && !art.isFastForwarding) {
                 if (touchTarget === $progress) (0, _progress.setCurrentTime)(art, event);
                 isDroging = true;
                 const { pageX, pageY } = event.touches[0];
@@ -4123,7 +4124,7 @@ function gestureInit(art, events) {
             }
         };
         const onTouchMove = (event)=>{
-            if (event.touches.length === 1 && isDroging && art.duration) {
+            if (event.touches.length === 1 && isDroging && art.duration && !art.isFastForwarding) {
                 const { pageX, pageY } = event.touches[0];
                 const direction = GetSlideDirection(startX, startY, pageX, pageY);
                 const isHorizontal = [
@@ -4148,7 +4149,7 @@ function gestureInit(art, events) {
             }
         };
         const onTouchEnd = ()=>{
-            if (isDroging) {
+            if (isDroging && !art.isFastForwarding) {
                 startX = 0;
                 startY = 0;
                 startTime = 0;
@@ -5286,6 +5287,7 @@ function fastForward(art) {
             isPress = true;
             lastPlaybackRate = art.playbackRate;
             art.playbackRate = constructor.FAST_FORWARD_VALUE;
+            art.isFastForwarding = true;
             (0, _utils.addClass)($player, "art-fast-forward");
         }, constructor.FAST_FORWARD_TIME);
     };
@@ -5294,11 +5296,13 @@ function fastForward(art) {
         if (isPress) {
             isPress = false;
             art.playbackRate = lastPlaybackRate;
+            art.isFastForwarding = false;
             (0, _utils.removeClass)($player, "art-fast-forward");
         }
     };
     proxy($video, "touchstart", onStart);
-    proxy(document, "touchmove", onStop);
+    // 只要手指没离开屏幕, 就一直倍速
+    // proxy(document, "touchmove", onStop);
     proxy(document, "touchend", onStop);
     return {
         name: "fastForward",


### PR DESCRIPTION
倍速快进：
① 快进的时候手指一抖可能会触发音量和进度调节。此commit禁用掉此行为。
② 滑动调节音量/进度时，在用户手指静止一定时间后再触发倍速快进，而不是从用户手指接触屏幕算起。


音量调节：移动端设备可以左右滑动调节进度。此commit在其基础上，新增"上下滑动调节音量"。 