### PR TITLE
fix: cancel video loading after destroying

### DIFF
--- a/packages/artplayer/src/template.js
+++ b/packages/artplayer/src/template.js
@@ -145,6 +145,7 @@ export default class Template {
     }
 
     destroy(removeHtml) {
+        this.$video.src = '';
         if (removeHtml) {
             this.$container.innerHTML = '';
         } else {


### PR DESCRIPTION
The video continues loading even after calling `.destroy()`, set the `src` attribute to an empty string to stop loading process.

调用`.destory()`后视频请求仍会继续加载，把`src`属性设置为空字符串来停止加载。