### PR TITLE
swap notice and seek event

### DIFF
--- a/packages/artplayer/src/player/seekMix.js
+++ b/packages/artplayer/src/player/seekMix.js
@@ -6,10 +6,10 @@ export default function seekMix(art) {
     def(art, 'seek', {
         set(time) {
             art.currentTime = time;
-            art.emit('seek', art.currentTime);
             if (art.duration) {
                 notice.show = `${secondToTime(art.currentTime)} / ${secondToTime(art.duration)}`;
             }
+            art.emit('seek', art.currentTime);
         },
     });
 


### PR DESCRIPTION
Currently, there is no way to suppress the notice during seeking because the event is emitted before the notice is displayed. Swap these two so that notice can be suppressed.