### PR TITLE
feat: 新增配置项gesture，是否开启手势快进快退操作。

### DIFF
--- a/packages/artplayer/src/events/gestureInit.js
+++ b/packages/artplayer/src/events/gestureInit.js
@@ -86,13 +86,15 @@ export default function gestureInit(art, events) {
             touchTarget = $progress;
             onTouchStart(event);
         });
-
-        events.proxy($video, 'touchstart', (event) => {
-            touchTarget = $video;
-            onTouchStart(event);
-        });
-
-        events.proxy($video, 'touchmove', onTouchMove);
+        
+        if(art.option.gesture){
+            events.proxy($video, 'touchstart', (event) => {
+                touchTarget = $video;
+                onTouchStart(event);
+            });
+            events.proxy($video, 'touchmove', onTouchMove);
+        }
+        
         events.proxy($progress, 'touchmove', onTouchMove);
         events.proxy(document, 'touchend', onTouchEnd);
     }

--- a/packages/artplayer/src/index.js
+++ b/packages/artplayer/src/index.js
@@ -152,6 +152,7 @@ export default class Artplayer extends Emitter {
             useSSR: false,
             playsInline: true,
             lock: false,
+            gesture: true,
             fastForward: false,
             autoPlayback: false,
             autoOrientation: false,


### PR DESCRIPTION
对于关闭手势操作我在业务上研究了很久，从外部确实无法关闭手势操作。目前只能通过改为直播模式来关闭。但是直播模式下，进度条也没了，所以不太友好。实际上只需要添加一个简单的配置项就可以实现开启/关闭手势操作。然而我们团队的业务确实需要关闭手势，所以暂时是通过修改node_modules的包在实现吗，说实话这有点傻，真的希望可以添加这个配置。