### PR TITLE
Fix incorrect type definition in Option interface

### DIFF
--- a/packages/artplayer-plugin-auto-thumbnail/types/artplayer-plugin-auto-thumbnail.d.ts
+++ b/packages/artplayer-plugin-auto-thumbnail/types/artplayer-plugin-auto-thumbnail.d.ts
@@ -6,7 +6,7 @@ export as namespace artplayerPluginAutoThumbnail;
 type Option = {
     url?: string;
     width?: number;
-    height?: number;
+    number?: number;
     scale?: number;
 };
 


### PR DESCRIPTION
Replaced the `height` property in the `Option` type with `number`, as `option.number` is used in the function, and `height` is generated through a hardcoded process.

https://github.com/zhw2590582/ArtPlayer/blob/bc401159b69ec023b5016737a52c38b25c085d8a/packages/artplayer-plugin-auto-thumbnail/src/index.js#L48

https://github.com/zhw2590582/ArtPlayer/blob/bc401159b69ec023b5016737a52c38b25c085d8a/packages/artplayer-plugin-auto-thumbnail/src/index.js#L10