### PR TITLE
Fix siblings helper typo

### DIFF
--- a/packages/artplayer/src/utils/dom.js
+++ b/packages/artplayer/src/utils/dom.js
@@ -50,12 +50,12 @@ export function getStyle(element, key, numberType = true) {
     return numberType ? parseFloat(value) : value;
 }
 
-export function sublings(target) {
+export function siblings(target) {
     return Array.from(target.parentElement.children).filter((item) => item !== target);
 }
 
 export function inverseClass(target, className) {
-    sublings(target).forEach((item) => removeClass(item, className));
+    siblings(target).forEach((item) => removeClass(item, className));
     addClass(target, className);
 }
 

--- a/packages/artplayer/types/utils.d.ts
+++ b/packages/artplayer/types/utils.d.ts
@@ -25,7 +25,7 @@ export type Utils = {
         key: K,
         numberType?: T,
     ): T extends true ? number : string;
-    sublings(target: HTMLElement): HTMLElement[];
+    siblings(target: HTMLElement): HTMLElement[];
     inverseClass(target: HTMLElement, className: string): void;
     tooltip(target: HTMLElement, msg: string, pos?: string): void;
     isInViewport(target: HTMLElement, offset?: number): boolean;


### PR DESCRIPTION
## Summary
- fix `sublings` helper typo in dom util
- update type definitions

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ad13e6898832c8a8cd7253ea4e403