### PR TITLE
Fix type names and comments

### DIFF
--- a/packages/artplayer/types/config.d.ts
+++ b/packages/artplayer/types/config.d.ts
@@ -1,5 +1,8 @@
 export type Config = {
-    propertys: [
+    /**
+     * Supported video properties
+     */
+    properties: [
         'audioTracks',
         'autoplay',
         'buffered',

--- a/packages/artplayer/types/option.d.ts
+++ b/packages/artplayer/types/option.d.ts
@@ -3,7 +3,7 @@ import { Setting } from './setting';
 import { Icons } from './icons';
 import { I18n } from './i18n';
 import { CssVar } from './cssVar';
-import { quality } from './quality';
+import { Quality } from './quality';
 import { ComponentOption } from './component';
 import Artplayer = require('./artplayer');
 
@@ -250,7 +250,7 @@ export type Option = {
     /**
      * Custom video quality list
      */
-    quality?: quality[];
+    quality?: Quality[];
 
     /**
      * Custom highlight list

--- a/packages/artplayer/types/player.d.ts
+++ b/packages/artplayer/types/player.d.ts
@@ -1,6 +1,6 @@
 import { CssVar } from './cssVar';
 import { CustomType, Thumbnails } from './option';
-import { quality } from './quality';
+import { Quality } from './quality';
 
 export type AspectRatio = 'default' | '4:3' | '16:9' | (`${number}:${number}` & Record<never, never>);
 export type PlaybackRate = 0.5 | 0.75 | 1.0 | 1.25 | 1.5 | 1.75 | 2.0 | (number & Record<never, never>);
@@ -62,7 +62,7 @@ export declare class Player {
     get subtitleOffset(): number;
     set subtitleOffset(time: number);
     set switch(url: string);
-    set quality(quality: quality[]);
+    set quality(quality: Quality[]);
     get thumbnails(): Thumbnails;
     set thumbnails(thumbnails: Thumbnails);
     pause(): void;

--- a/packages/artplayer/types/quality.d.ts
+++ b/packages/artplayer/types/quality.d.ts
@@ -1,4 +1,4 @@
-export type quality = {
+export type Quality = {
     /**
      * Whether the default is selected
      */

--- a/packages/artplayer/types/setting.d.ts
+++ b/packages/artplayer/types/setting.d.ts
@@ -51,7 +51,7 @@ export type Setting = {
     selector?: Setting[];
 
     /**
-     * Wnen the setting was mounted
+     * When the setting was mounted
      */
     mounted?(this: Artplayer, panel: HTMLDivElement, item: Setting): void;
 


### PR DESCRIPTION
## Summary
- correct typo `propertys` -> `properties`
- rename `quality` type to `Quality`
- update references to `Quality` in player and option types
- fix comment typo in `setting.d.ts`

## Testing
- `npm run prettier`
- `npm run build:ts` *(fails: Cannot find package 'cpy')*
- `node test/types.test.js` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_684c1a7b3dc8832cbbc28a7c2d10f6f4