### PR TITLE
Fix typos and polish English docs

### DIFF
--- a/packages/artplayer-vitepress/docs/en/advanced/built-in.md
+++ b/packages/artplayer-vitepress/docs/en/advanced/built-in.md
@@ -314,7 +314,7 @@ Manage the subtitle features of the player
 - `switch` method sets the current subtitle address and options
 - `textTrack` Get the current subtitle track
 - `activeCues` Get the currently active subtitle list
-- `cues` Get the the subtitle list
+- `cues` Get the subtitle list
 
 <div className="run-code">▶ Run Code</div>
 

--- a/packages/artplayer-vitepress/docs/en/advanced/plugin.md
+++ b/packages/artplayer-vitepress/docs/en/advanced/plugin.md
@@ -2,7 +2,7 @@
 
 Once you know the player's `properties`, `methods`, and `events`, writing plugins is very simple.
 
-You can load the plugin functions when instantiated.
+You can load plugin functions during instantiation.
 
 <div className="run-code">▶ Run Code</div>
 
@@ -28,9 +28,7 @@ art.on('ready', () => {
     console.info(art.plugins.myPlugin);
 });
 ```
-Here's the translation of the provided text into English while preserving the Markdown formatting:
-
-A function that allows loading plugins after instantiation
+You can also load plugins after instantiation:
 
 <div className="run-code">▶ Run Code</div>
 

--- a/packages/artplayer-vitepress/docs/en/component/setting.md
+++ b/packages/artplayer-vitepress/docs/en/component/setting.md
@@ -38,7 +38,7 @@ var art = new Artplayer({
     settings: [
         {
             html: 'Button',
-            icon: '<img width="22" heigth="22" src="/assets/img/state.svg">',
+            icon: '<img width="22" height="22" src="/assets/img/state.svg">',
             tooltip: 'tooltip',
 			onClick(item, $dom, event) {
                 console.info(item, $dom, event);
@@ -189,7 +189,7 @@ var art = new Artplayer({
         {
             html: 'PIP Mode',
             tooltip: 'Close',
-            icon: '<img width="22" heigth="22" src="/assets/img/state.svg">',
+            icon: '<img width="22" height="22" src="/assets/img/state.svg">',
             switch: false,
             onSwitch: function (item, $dom, event) {
                 console.info(item, $dom, event);
@@ -257,7 +257,7 @@ art.setting.show = true;
 art.setting.add({
     html: 'Slider',
     tooltip: '5x',
-    icon: '<img width="22" heigth="22" src="/assets/img/state.svg">',
+    icon: '<img width="22" height="22" src="/assets/img/state.svg">',
     range: [5, 1, 10, 1],
 });
 ```
@@ -277,7 +277,7 @@ var art = new Artplayer({
             name: 'slider',
             html: 'Slider',
             tooltip: '5x',
-            icon: '<img width="22" heigth="22" src="/assets/img/state.svg">',
+            icon: '<img width="22" height="22" src="/assets/img/state.svg">',
             range: [5, 1, 10, 1],
         },
     ],
@@ -306,7 +306,7 @@ var art = new Artplayer({
             name: 'slider',
             html: 'Slider',
             tooltip: '5x',
-            icon: '<img width="22" heigth="22" src="/assets/img/state.svg">',
+            icon: '<img width="22" height="22" src="/assets/img/state.svg">',
             range: [5, 1, 10, 1],
         },
     ],
@@ -321,7 +321,7 @@ art.on('ready', () => {
             name: 'slider',
             html: 'PIP Mode',
             tooltip: 'Close',
-            icon: '<img width="22" heigth="22" src="/assets/img/state.svg">',
+            icon: '<img width="22" height="22" src="/assets/img/state.svg">',
             switch: false,
         });
     }, 3000);

--- a/packages/artplayer-vitepress/docs/en/index.md
+++ b/packages/artplayer-vitepress/docs/en/index.md
@@ -72,7 +72,7 @@ The player's size depends on the size of the container `container`, so your cont
 
 :::
 
-::: tip You can see more examples of use at the following link
+::: tip You can find more usage examples at the link below
 
 [/packages/artplayer-template](https://github.com/zhw2590582/ArtPlayer/tree/master/packages/artplayer-template)
 
@@ -219,7 +219,7 @@ export default App;
 ```
 
 :::
-::: warning Non-responsive Artplayer:
+::: warning Non-responsive Artplayer
 
 In `React.js`, directly modifying the `option` will not change the player
 


### PR DESCRIPTION
## Summary
- fix typo in built-in doc
- reword plugin documentation and remove leftover translation text
- clarify "tip" link wording and update warning in main docs
- correct repeated typo `heigth` in setting.md

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run prettier`

------
https://chatgpt.com/codex/tasks/task_e_6854bd2c6f1c832cbfee65834ebd3a64