### PR TITLE
Fix minor bug and typo

### DIFF
--- a/packages/artplayer/src/player/miniMix.js
+++ b/packages/artplayer/src/player/miniMix.js
@@ -112,7 +112,7 @@ export default function miniMix(art) {
                 const $mini = createMini();
                 const top = storage.get('top');
                 const left = storage.get('left');
-                if (top && left) {
+                if (typeof top === 'number' && typeof left === 'number') {
                     setStyle($mini, 'top', `${top}px`);
                     setStyle($mini, 'left', `${left}px`);
                     if (!isInViewport($mini)) {

--- a/packages/artplayer/src/setting/index.js
+++ b/packages/artplayer/src/setting/index.js
@@ -110,7 +110,7 @@ export default class Setting extends Component {
             const item = option[index];
 
             if (item?.name) {
-                errorHandle(!names.includes(item.name), `The [${item.name}] is already exist in [setting]`);
+                errorHandle(!names.includes(item.name), `The [${item.name}] already exists in [setting]`);
                 names.push(item.name);
             } else {
                 item.name = `setting-${this.id++}`;


### PR DESCRIPTION
## Summary
- avoid ignoring stored mini player position when 0
- fix grammatical error in setting component

## Testing
- `node --check` on all JS files
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6854c12f8280832c9105b84046b1b2f3