### PR TITLE
perf: 进度条新增 `padding-top` 样式，防止点击进度条误触暂停

### DIFF
--- a/docs/assets/ts/artplayer.d.ts
+++ b/docs/assets/ts/artplayer.d.ts
@@ -799,6 +799,7 @@ export interface CssVar {
   '--art-border-radius': string
   '--art-progress-height': string
   '--art-progress-color': string
+  '--art-progress-top-gap': string
   '--art-hover-color': string
   '--art-loaded-color': string
   '--art-state-size': string

--- a/packages/artplayer/src/style/progress.less
+++ b/packages/artplayer/src/style/progress.less
@@ -3,6 +3,7 @@
         position: relative;
         z-index: 0;
         pointer-events: auto;
+        padding-top: var(--art-progress-top-gap);
         padding-bottom: var(--art-bottom-gap);
 
         .art-control-progress {

--- a/packages/artplayer/src/style/variables.less
+++ b/packages/artplayer/src/style/variables.less
@@ -8,6 +8,7 @@
     --art-border-radius: 3px;
     --art-progress-height: 6px;
     --art-progress-color: rgba(255, 255, 255, 0.25);
+    --art-progress-top-gap: 8px;
     --art-hover-color: rgba(255, 255, 255, 0.25);
     --art-loaded-color: rgba(255, 255, 255, 0.25);
     --art-state-size: 80px;

--- a/packages/artplayer/types/cssVar.d.ts
+++ b/packages/artplayer/types/cssVar.d.ts
@@ -8,6 +8,7 @@ export interface CssVar {
   '--art-border-radius': string
   '--art-progress-height': string
   '--art-progress-color': string
+  '--art-progress-top-gap': string
   '--art-hover-color': string
   '--art-loaded-color': string
   '--art-state-size': string


### PR DESCRIPTION
点击进度条的时候，经常会点击到暂停，YouTube 的方法是直接把进度条放到 `ytp-chapter-hover-container`，高度为 `16px`，我这里直接设置进度条的 `padding-top` 为 `8px`，可以有效防止点进度条触发暂停。