### PR TITLE
use currentSrc to show video url

### DIFF
--- a/packages/artplayer/src/template.js
+++ b/packages/artplayer/src/template.js
@@ -63,7 +63,7 @@ export default class Template {
                 </div>
                 <div class="art-info-item">
                   <div class="art-info-title">Video url:</div>
-                  <div class="art-info-content" data-video="src"></div>
+                  <div class="art-info-content" data-video="currentSrc"></div>
                 </div>
                 <div class="art-info-item">
                   <div class="art-info-title">Video volume:</div>


### PR DESCRIPTION
shaka-player will set `src` to empty if playing hls or mpd. Using `currentSrc` will show the blob url that's in use.