### PR TITLE
fix(types): correct notice.show getter return type

### DIFF
--- a/packages/artplayer/types/artplayer.d.ts
+++ b/packages/artplayer/types/artplayer.d.ts
@@ -152,7 +152,7 @@ export default class Artplayer extends Player {
 
   readonly notice: {
     timer: number | null
-    get show(): boolean
+    get show(): string | Error | false | ''
     set show(msg: string | Error | false | '')
     destroy: () => void
   }


### PR DESCRIPTION
## Problem

Assigning a string to `art.notice.show` triggers TS2322: "Type 'string' is not assignable to type 'boolean'".

## Cause

In `packages/artplayer/types/artplayer.d.ts`, the getter is declared as `get show(): boolean` while the setter accepts `string | Error | false | ''`. TypeScript checks property assignment against the getter's return type, so assigning a string fails even though the runtime setter accepts it. This was introduced in v5.4.0 (v5.3.0 only declared `set show(msg: string)`).

## Fix

Align the getter's return type with the setter's accepted type:

`get show(): string | Error | false | ''`

Type-only change; no runtime behavior is affected.
